### PR TITLE
Fix StringUtil#capitalise throwing a StringIndexOutOfBoundsException.

### DIFF
--- a/src/main/java/com/dsh105/commodus/StringUtil.java
+++ b/src/main/java/com/dsh105/commodus/StringUtil.java
@@ -100,7 +100,9 @@ public class StringUtil {
     public static String capitalise(String string, boolean forceLowerCase) {
         String[] parts = string.split(" ");
         for (int i = 0; i < parts.length; i++) {
-            parts[i] = parts[i].substring(0, 1).toUpperCase() + (forceLowerCase ? parts[i].substring(1).toLowerCase() : parts[i].substring(1));
+            if (parts[i].length > 0) {
+                parts[i] = parts[i].substring(0, 1).toUpperCase() + (forceLowerCase ? parts[i].substring(1).toLowerCase() : parts[i].substring(1));
+            }
         }
         return combineArray(0, " ", parts);
     }


### PR DESCRIPTION
Currently this throws the following exception when typing the command '/pet  test':

```
[05:41:47] [Server thread/WARN]: Unexpected exception while parsing console command "pet  test"
org.bukkit.command.CommandException: Unhandled exception executing 'pet  test' in com.dsh105.echopet.commands.util.DynamicPluginCommand(pet)
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:188) ~[Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at org.bukkit.craftbukkit.v1_7_R4.CraftServer.dispatchCommand(CraftServer.java:820) ~[Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at org.bukkit.craftbukkit.v1_7_R4.CraftServer.dispatchServerCommand(CraftServer.java:806) [Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at net.minecraft.server.v1_7_R4.DedicatedServer.aB(DedicatedServer.java:335) [Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at net.minecraft.server.v1_7_R4.DedicatedServer.v(DedicatedServer.java:299) [Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at net.minecraft.server.v1_7_R4.MinecraftServer.u(MinecraftServer.java:584) [Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at net.minecraft.server.v1_7_R4.MinecraftServer.run(MinecraftServer.java:490) [Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	at net.minecraft.server.v1_7_R4.ThreadServerApplication.run(SourceFile:628) [Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: 1
	at java.lang.String.substring(Unknown Source) ~[?:1.8.0_45]
	at com.dsh105.echopet.libs.com.dsh105.commodus.StringUtil.capitalise(StringUtil.java:103) ~[?:?]
	at com.dsh105.echopet.libs.com.dsh105.commodus.StringUtil.capitalise(StringUtil.java:90) ~[?:?]
	at com.dsh105.echopet.compat.api.util.PetUtil.formPetFromArgs(PetUtil.java:141) ~[?:?]
	at com.dsh105.echopet.commands.PetCommand.onCommand(PetCommand.java:576) ~[?:?]
	at com.dsh105.echopet.commands.util.DynamicPluginCommand.execute(DynamicPluginCommand.java:46) ~[?:?]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:181) ~[Krunchit-1.7.10-R0.1-SNAPSHOT.jar:git-Krunchit-2180b72]
	... 7 more
```